### PR TITLE
Typo in train_xent.py

### DIFF
--- a/train_xent.py
+++ b/train_xent.py
@@ -50,7 +50,7 @@ while step < totalSteps:
 
     archiveI = step%args.numArchives + 1
     archive_start_time = time.time()
-    ark_file = '{}/egs.{}.ark'.format(args.egsDir,archiveI)
+    ark_file = '{}/egs.{}.ark'.format(args.featDir,archiveI)
     print('Reading from archive %d' %archiveI)
 
     preFetchRatio = args.preFetchRatio


### PR DESCRIPTION
Hi, we found a typo in the train_xent.py where "egsDir" is an old naming in the history.